### PR TITLE
Change method of opening ZIP files

### DIFF
--- a/src/PKPass.php
+++ b/src/PKPass.php
@@ -447,7 +447,7 @@ class PKPass
         // Package file in Zip (as .pkpass)
         $zip = new ZipArchive();
         $filename = tempnam($this->tempPath, 'pkpass');
-        if (!$zip->open($filename, ZipArchive::CREATE)) {
+        if (!$zip->open($filename, ZipArchive::OVERWRITE)) {
             throw new PKPassException('Could not open ' . basename($filename) . ' with ZipArchive extension.');
         }
         $zip->addFromString('signature', $signature);


### PR DESCRIPTION
PHP 8 has deprecated opening empty files for opening zip. This is caused by deprection in libzip 1.6.0. This PR mitigates the issue by changing method of opening ZIP files from `ZipArchive::CREATE` to `ZipArchive::OVERWRITE`

[Relevant PHP commit](https://github.com/php/php-src/commit/a4d12f46d1233da4f3518d918c925362b1d9465a)
[Relevant PHP bug report](https://bugs.php.net/bug.php?id=79296)