### PR TITLE
Add ci, docs, examples to export ignore via gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/.github export-ignore
+/docs export-ignore
+/examples export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore


### PR DESCRIPTION
This make the installed packages smaller, this files are not required to run the library.

Reference: https://getcomposer.org/doc/02-libraries.md#light-weight-distribution-packages Example:  https://github.com/Seldaek/monolog/blob/3.5.0/.gitattributes 